### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: php
 php:
 - 7.1
 - 7.2
+- 7.3
+- 7.4
 
 install:
 - travis_retry composer install --no-interaction

--- a/composer.json
+++ b/composer.json
@@ -11,14 +11,16 @@
         }
     ],
     "require": {
-        "php": ">=7.1.0"
+        "php": ">=7.1.0",
+        "ext-mbstring": "*"
     },
     "autoload": {
-        "classmap": [
-            "src/"
-        ],
         "psr-4": {
-            "Narokishi\\WordsFromNumber\\": "src/",
+            "Narokishi\\NumberToWords\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
             "Narokishi\\Tests\\": "tests/"
         }
     },

--- a/tests/AbstractDictionaryTest.php
+++ b/tests/AbstractDictionaryTest.php
@@ -19,7 +19,7 @@ class AbstractDictionaryTest extends TestCase
     /**
      * @throws \ReflectionException
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->dictionaryClass = $this->getMockForAbstractClass(AbstractDictionary::class);
     }

--- a/tests/Dictionaries/PolishDictionaryTest.php
+++ b/tests/Dictionaries/PolishDictionaryTest.php
@@ -17,7 +17,7 @@ class PolishDictionaryTest extends TestCase
      */
     protected $dictionaryClass;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->dictionaryClass = new PolishDictionary;
     }

--- a/tests/Transformers/PolishTransformerTest.php
+++ b/tests/Transformers/PolishTransformerTest.php
@@ -17,7 +17,7 @@ class PolishTransformerTest extends TestCase
      */
     protected $transformerClass;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->transformerClass = new PolishTransformer;
     }


### PR DESCRIPTION
# Changed log
- Add `php-7.3` and `php-7.4` versions during Travis CI build.
- It seems that this package uses the `mb_*` functions and it should check `ext-mbstring` extension is installed during `composer install` command.
- It seems that the package uses the `PSR-4` autoloading and it's fine to remove classmap autoloading approach.
- The PHPUnit fixtures should be `protected setUp`. 